### PR TITLE
Advance Chrome Driver version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     python python-pip curl unzip vim libgconf-2-4 --fix-missing
 
 
-ENV CHROMEDRIVER_VERSION 2.23
+ENV CHROMEDRIVER_VERSION 2.27
 
 RUN curl -SLO "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
   && unzip "chromedriver_linux64.zip" -d /usr/local/bin \


### PR DESCRIPTION
When I followed the instructions in `README.md` I received the following:

```
$ git clone https://github.com/target/winnaker
Cloning into 'winnaker'...
remote: Counting objects: 19, done.
remote: Total 19 (delta 0), reused 0 (delta 0), pack-reused 19
Unpacking objects: 100% (19/19), done.
Checking connectivity... done.
$ cd winnaker/
Andrews-MacBook-Pro:winnaker Andrew$ docker build -t winnaker .
Sending build context to Docker daemon 112.6 kB
Step 1 : FROM debian:jessie
 ---> e5599115b6a6
Step 2 : RUN apt-get update && apt-get install -y     xvfb chromium     python python-pip curl unzip vim libgconf-2-4 --fix-missing
 ---> Using cache
 ---> 4115b7d54adf
Step 3 : ENV CHROMEDRIVER_VERSION 2.23
 ---> Using cache
 ---> 35d3887de617
Step 4 : RUN curl -SLO "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip"   && unzip "chromedriver_linux64.zip" -d /usr/local/bin   && rm "chromedriver_linux64.zip"
 ---> Using cache
 ---> 26a0091c0eb2
Step 5 : ADD ./src/requirements.txt /tmp/requirements.txt
 ---> Using cache
 ---> 47379061123f
Step 6 : RUN pip install -r /tmp/requirements.txt
 ---> Using cache
 ---> d793bf0d7bc7
Step 7 : WORKDIR /app
 ---> Using cache
 ---> 429298192eb4
Step 8 : ENTRYPOINT python main.py -hl
 ---> Using cache
 ---> 76dc054c71a0
Successfully built 76dc054c71a0
Andrews-MacBook-Pro:winnaker Andrew$ ./run.sh
rm: ./src/outputs/*: No such file or directory
-------------------------------------------------------
 The config file location:  src/config.sh
-------------------------------------------------------
WINNAKER_USERNAME: <DETRACTED>
WINNAKER_PASSWORD: <DETRACTED>
WINNAKER_SPINNAKER_URL: http://<DETRACTED>:9000/
WINNAKER_APP_NAME: hellodeploy
WINNAKER_PIPELINE_NAME: Deploy Preprod
WINNAKER_HIPCHAT_POSTURL:
WINNAKER_MAX_WAIT_PIPELINE set ✓

____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .______
\   \  /  \  /   / |  | |  \ |  | |  \ |  |     /   \     |  |/  / |   ____||   _   \   \/    \/   /  |  | |   \|  | |   \|  |    /  ^  \    |  '  /  |  |__   |  |_)  |
  \            /   |  | |  . `  | |  . `  |   /  /_\  \   |    <   |   __|  |      /
   \    /\    /    |  | |  |\   | |  |\   |  /  _____  \  |  .  \  |  |____ |  |\  \----.
    \__/  \__/     |__| |__| \__| |__| \__| /__/     \__\ |__|\__\ |_______|| _| `._____|


Traceback (most recent call last):
  File "main.py", line 43, in <module>
    s = Spinnaker()
  File "/app/models.py", line 32, in __init__
    self.driver = webdriver.Chrome(chrome_options=chrome_options)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/chrome/webdriver.py", line 69, in __init__
    desired_capabilities=desired_capabilities)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 92, in __init__
    self.start_session(desired_capabilities, browser_profile)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 179, in start_session
    response = self.execute(Command.NEW_SESSION, capabilities)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 234, in execute
    response = self.command_executor.execute(driver_command, params)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/remote_connection.py", line 408, in execute
    return self._request(command_info[0], url, body=data)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/remote_connection.py", line 440, in _request
    resp = self._conn.getresponse()
  File "/usr/lib/python2.7/httplib.py", line 1111, in getresponse
    response.begin()
  File "/usr/lib/python2.7/httplib.py", line 444, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python2.7/httplib.py", line 408, in _read_status
    raise BadStatusLine(line)
httplib.BadStatusLine: ''
```

Updating the ChromeDriver version to 2.27 fixed the issue for me.