### PR TITLE
Select a pipeline instead of an execution

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,8 +4,6 @@ from models import *
 from selenium import webdriver
 
 
-
-
 if __name__ == "__main__":
 
     print ("""
@@ -29,9 +27,10 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
                         help="the name of pipline to test", default=os.environ["WINNAKER_PIPELINE_NAME"])
     parser.add_argument("-nl", "--nologin",
                         help="will not attempt to login", action="store_true")
+    parser.add_argument("-nlb", "--nolastbuild",
+                        help="will not attempt to check last build status or stages", action="store_true")
     parser.add_argument(
         "-hl", "--headless",  help="will run in an xfvb display ", action="store_true")
-
 
     args = parser.parse_args()
 
@@ -44,9 +43,10 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
     if not args.nologin:
         s.login()
     s.get_pipeline(args.app, args.pipeline)
-    print ("- Last build status "+s.get_last_build().status.encode('utf-8'))
-    print ("- Screenshot Stages")
-    s.get_stages()
+    if not args.nolastbuildstatus:
+        print("- Last build status " + s.get_last_build().status.encode('utf-8'))
+        print("- Screenshot Stages")
+        s.get_stages()
 
     if args.start:
         s.start_manual_execution(force_bake=args.forcebake)

--- a/src/main.py
+++ b/src/main.py
@@ -43,7 +43,7 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
     if not args.nologin:
         s.login()
     s.get_pipeline(args.app, args.pipeline)
-    if not args.nolastbuildstatus:
+    if not args.nolastbuild:
         print("- Last build status " + s.get_last_build().status.encode('utf-8'))
         print("- Screenshot Stages")
         s.get_stages()

--- a/src/models.py
+++ b/src/models.py
@@ -78,13 +78,18 @@ class Spinnaker():
         self.check_page_contains_error()
         self.get_pipelines(appname)
         time.sleep(0.5)
-        searchbox = "//div[@class='form-group nav-search']//input[@type='search']"
-        e = wait_for_xpath_presence(self.driver, searchbox)
-        e.send_keys(pipelinename)
+        checkbox = "//div[@class='nav']//execution-filters//label[contains(.,'  %s')]/input[@type='checkbox']" % pipelinename
+        e = wait_for_xpath_presence(
+            self.driver, checkbox, be_clickable=True)
+        move_to_element(self.driver, e, click=True)
+        time.sleep(2)
+        if not e.get_attribute('checked'):
+            e = wait_for_xpath_presence(
+                self.driver, checkbox, be_clickable=True)
+            e.click()
+        time.sleep(2)
         self.driver.save_screenshot("./outputs/pipelines.png")
-        time.sleep(1)
-        e.send_keys(Keys.RETURN)
-        print("- Searched for pipleline " + pipelinename + " successfully ✓")
+        print("- Selected pipleline " + pipelinename + " successfully ✓")
 
     def start_manual_execution(self, force_bake=False):
         self.check_page_contains_error()
@@ -197,7 +202,8 @@ class Build():
 
     def __init__(self, trigger_details, execution_summary):
         try:
-            self.status = execution_summary.split("\n")[0].replace("Status: ", "")
+            self.status = execution_summary.split(
+                "\n")[0].replace("Status: ", "")
             self.duration = execution_summary.split(
                 "\n")[1].replace("Duration: ", "")
             self.type_of_start = ""
@@ -211,7 +217,7 @@ class Build():
                 self.datetime_started = trigger_details.split("\n")[1]
             self.detail = trigger_details.split("\n")[2]
             self.stack = trigger_details.split("\n")[3]
-        except (ValueError,IndexError):
+        except (ValueError, IndexError):
             pass
 
     def status_is_valid(self):

--- a/src/models.py
+++ b/src/models.py
@@ -132,8 +132,11 @@ class Spinnaker():
             status = self.get_last_build().status
             if "RUNNING" in status:
                 time.sleep(10)
+            elif "NOT_STARTED" in status:
+                print("Pipeline has not yet started.")
+                time.sleep(10)
             elif "SUCCEEDED" in status:
-                print("\nCongratulations pipleline run was successfull")
+                print("\nCongratulations pipleline run was successful.")
                 print_passed()
                 self.get_stages(n=2)
                 return 0


### PR DESCRIPTION
I have been having an issue where pipelines couldn't be found even though they did exist. It only presents itself on a fresh instance of Spinnaker, or on an instance with a flushed cache. 

I took a look and noticed that the search box filter on the pipelines screen actually searches for executions opposed to pipelines. In the case that there aren't any executions, pipelines can not be found. 

This PR should address that issue.

