### PR TITLE
Adding logging mechanism using python logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ outputs
 winnaker.egg-info/
 .idea
 winnaker.iml
+winnaker.log

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name='winnaker',
       description='An audit tool that tests the whole system functionality of Spinnaker',
       author='Target Corporation',
-      version='0.5.0',
+      version='0.6.0',
       license='MIT',
       packages=find_packages(),
       install_requires=[

--- a/winnaker/config.sh
+++ b/winnaker/config.sh
@@ -27,9 +27,9 @@ export WINNAKER_XPATH_START_MANUAL_EXECUTION="//div[contains(@class, 'execution-
 # TODO Try this later
 # //label[contains(.,'Force')]
 export WINNAKER_XPATH_FORCE_REBAKE="//input[@type='checkbox' and @ng-model='vm.command.trigger.rebake']"
-export WINNAKER_XPATH_PIPELINE_EXECUTION_SUMMARY="//execution-groups[1]//div[@class='execution-summary']]"
+export WINNAKER_XPATH_PIPELINE_EXECUTION_SUMMARY="//execution-groups[1]//div[@class='execution-summary']"
 export WINNAKER_XPATH_PIPLELINE_TRIGGER_DETAILS="//execution-groups[1]//ul[@class='trigger-details']"
-export WINNAKER_XPATH_PIPLELINE_DETAILS_LINK="//execution-groups[1]//execution-status//div/a[contains(., 'Details')]]"
+export WINNAKER_XPATH_PIPLELINE_DETAILS_LINK="//execution-groups[1]//execution-status//div/a[contains(., 'Details')]"
 
 
 

--- a/winnaker/helpers.py
+++ b/winnaker/helpers.py
@@ -68,7 +68,6 @@ def wait_for_xpath_presence(driver, xpath, be_clickable=False):
         driver.save_screenshot("./outputs/debug" + now() + ".png")
         a_nice_refresh(driver)
         raise StaleElementReferenceException
-
     driver.save_screenshot("./outputs/error_driver_" + now() + ".png")
 
 

--- a/winnaker/main.py
+++ b/winnaker/main.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import argparse
+import argparse, logging, os, sys
 from winnaker.models import *
 from selenium import webdriver
 import pkg_resources  # part of setuptools
+
 
 def main():
     print ("""
@@ -14,10 +15,6 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
     \__/  \__/     |__| |__| \__| |__| \__| /__/     \__\ |__|\__\ |_______|| _| `._____|
 
     """)
-    import os
-    version = pkg_resources.require("winnaker")[0].version
-    print ("Winnaker Version: "+version)
-
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", "--start", help="starts manual execution of the pipline",
                         action="store_true")
@@ -33,31 +30,57 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
                         help="will not attempt to check last build status or stages", action="store_true")
     parser.add_argument(
         "-hl", "--headless",  help="will run in an xfvb display ", action="store_true")
-
+    parser.add_argument("-v", "--verbose", help="print more logs, DEBUG level", action="store_true")
     args = parser.parse_args()
-    print ("Current Config")
-    print (args)
+
+    ## Logging setup
+    if args.verbose:
+        log_level = logging.DEBUG
+    else:
+        log_level =  logging.INFO
+    logFormatter = logging.Formatter("%(asctime)s [%(levelname)s]  %(message)s")
+    rootLogger = logging.getLogger()
+    rootLogger.setLevel(log_level)
+
+    fileHandler = logging.FileHandler("winnaker.log")
+    fileHandler.setFormatter(logFormatter)
+    rootLogger.addHandler(fileHandler)
+
+    consoleHandler = logging.StreamHandler(sys.stdout)
+    consoleHandler.setFormatter(logFormatter)
+    rootLogger.addHandler(consoleHandler)
+
+    version = pkg_resources.require("winnaker")[0].version
+    logging.info("Winnaker Version: {}".format(version))
+    logging.info("Current Config: {}".format(args))
+
     if args.headless:
+        logging.debug("Starting virtual display")
         from pyvirtualdisplay import Display
         display = Display(visible=0, size=(2560, 1440))
         display.start()
+        logging.debug("Started virtual display")
 
     s = Spinnaker()
     if not args.nologin:
+        logging.debug("Starting login")
         s.login()
     s.get_pipeline(args.app, args.pipeline)
     if not args.nolastbuild:
-        print("- Last build status " + s.get_last_build().status.encode('utf-8'))
-        print("- Screenshot Stages")
-        import os
-        print (os.getcwd())
+        logging.debug("Going into nolastbuild block")
+        logging.info("- Last build status: {}".format(s.get_last_build().status.encode('utf-8')))
+        logging.info("- Screenshot Stages")
+        logging.info("- Current working directory: {}".format(os.getcwd()))
         s.get_stages()
 
     if args.start:
+        logging.debug("Going into start block")
         s.start_manual_execution(force_bake=args.forcebake)
 
     if args.headless:
+        logging.debug("Stopping virtualdisplay")
         display.stop()
+        logging.debug("virtualdisplay stopped")
 
 if __name__ == "__main__":
     main()

--- a/winnaker/models.py
+++ b/winnaker/models.py
@@ -5,11 +5,9 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-import time
-import os
+import time, os, sys, logging
 from winnaker.helpers import *
 from datetime import datetime
-import sys
 from tqdm import tqdm
 
 ERROR_LIST = {"Whitelabel Error Page": "Check clouddriver",
@@ -44,13 +42,14 @@ class Spinnaker():
         signinbutton = get_env("WINNAKER_XPATH_LOGIN_SUBMIT", "//input[@type='submit']")
 
         e = wait_for_xpath_presence(self.driver, usernamebox)
+        logging.debug("Logging in as: {}".format(os.environ["WINNAKER_USERNAME"]))
         e.send_keys(os.environ['WINNAKER_USERNAME'])
         e = wait_for_xpath_presence(self.driver, passwordbox)
         self.driver.save_screenshot(os.environ["WINNAKER_OUTPUTPATH"]+"/login.png")
         e.send_keys(os.environ['WINNAKER_PASSWORD'])
         e = wait_for_xpath_presence(self.driver, signinbutton)
         e.click()
-        print("- Logged in to the spinnaker")
+        logging.info("- Logged in to the spinnaker")
 
     def get_application(self, appname):
         self.check_page_contains_error()
@@ -68,7 +67,7 @@ class Spinnaker():
         e = wait_for_xpath_presence(self.driver, app_xpath)
         e.click()
         time.sleep(1)
-        print("- Searched for application " + appname)
+        logging.info("- Searched for application: {}".format(appname))
 
     def get_pipelines(self, appname):
         self.get_application(appname)
@@ -92,7 +91,7 @@ class Spinnaker():
             e.click()
         time.sleep(2)
         self.driver.save_screenshot(os.environ["WINNAKER_OUTPUTPATH"]+"/pipelines.png")
-        print("- Selected pipeline " + pipelinename + " successfully")
+        logging.info("- Selected pipeline: {} successfully".format(pipelinename))
 
     def start_manual_execution(self, force_bake=False):
         self.check_page_contains_error()
@@ -122,33 +121,31 @@ class Spinnaker():
         MAX_WAIT_FOR_RUN = int(
             os.environ["WINNAKER_MAX_WAIT_PIPELINE"]) * 60.00
         start_time = time.time()
-        print("- Starting Manual Execution")
+        logging.info("- Starting Manual Execution")
         time.sleep(10)  # To give enough time for pipeleine kick off show up
-        print("\t Running ... (will wait up to " +
-              str(int(MAX_WAIT_FOR_RUN / 60)) + ") minutes")
+        logging.info("\t Running ... (will wait up to {} minutes".format(int(MAX_WAIT_FOR_RUN / 60)))
         for i in tqdm(range(int(MAX_WAIT_FOR_RUN / 10))):
             if time.time() - start_time > MAX_WAIT_FOR_RUN:
-                print("The run is taking more than " +
-                      str(MAX_WAIT_FOR_RUN / 60) + " minutes")
-                print("Considering it as an error")
+                logging.error("The run is taking more than {} minutes".format(int(MAX_WAIT_FOR_RUN / 60)))
+                logging.error("Considering it as an error")
                 sys.exit(1)
             status = self.get_last_build().status
             if "RUNNING" in status:
                 time.sleep(10)
             elif "NOT_STARTED" in status:
-                print("Pipeline has not yet started.")
+                logging.info("Pipeline has not yet started.")
                 time.sleep(10)
             elif "SUCCEEDED" in status:
-                print("\nCongratulations pipleline run was successful.")
+                logging.info("\nCongratulations pipleline run was successful.")
                 print_passed()
                 self.get_stages(n=2)
                 return 0
             elif "TERMINAL" in status:
-                print("Pipleline stopped with terminal state. screenshot generated.")
+                logging.error("Pipeline stopped with terminal state. screenshot generated.")
                 print_failed()
                 sys.exit(1)
             else:
-                print("Error: something went wrong " + status)
+                logging.error("Error: something went wrong {}".format(status))
                 sys.exit(2)
 
     def get_last_build(self):
@@ -183,11 +180,11 @@ class Spinnaker():
                 try:
                     e = self.wait.until(
                         EC.presence_of_element_located((By.XPATH, xpath)))
-                    print("- Stage Detail: \n\t" +
-                          e.text.replace("\n", "\n\t"))
+                    logging.info("- Stage Detail: \n\t" +
+                          e.text.replace("\n", "\n\t\n"))
                     for error in ERROR_LIST:
                         if error in e.text:
-                            print("\t Stage Failed: " + e.text)
+                            logging.error("\t Stage Failed: {}".format(e.text))
                             sys.exit(1)
                 except TimeoutException:
                     continue
@@ -196,10 +193,11 @@ class Spinnaker():
     def check_page_contains_error(self):
         for error in ERROR_LIST.keys():
             if error in get_body_text(self.driver):
-                print("- Failed for : " + error)
-                print("- Suggestion : " + ERROR_LIST[error])
+                logging.error("- Failed for: {}".format(error))
+                logging.info("- Suggestion: {}".format(ERROR_LIST[error]))
                 print_failed()
                 sys.exit(1)
+                # TODO: Is this needed? It should never occur because of the sys.exit(1)
                 return True
             assert error not in get_body_text(self.driver)
 
@@ -215,7 +213,7 @@ class Build():
                 "\n")[1].replace("Duration: ", "")
             self.type_of_start = ""
             self.username = trigger_details.split("\n")[0]
-            print(self.username)
+            logging.info("Username: {}".format(self.username))
             if " CDT" in trigger_details:
                 self.datetime_started = datetime.strptime(trigger_details.split(
                     "\n")[1].replace(" CDT", ""), '%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
To get more verbose logging use -v. Beware this prints out EVERYTHING selenium does because selenium also incorporates the verbose logger. Logging output is also saved to a winnaker.log file wherever the command is run.

Here is the example log output

```
z001nqk:~/Repos/EdwinAvalos/winnaker$ winnaker -s -nlb

____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .______
\   \  /  \  /   / |  | |  \ |  | |  \ |  |     /   \     |  |/  / |   ____||   _  \
 \   \/    \/   /  |  | |   \|  | |   \|  |    /  ^  \    |  '  /  |  |__   |  |_)  |
  \            /   |  | |  . `  | |  . `  |   /  /_\  \   |    <   |   __|  |      /
   \    /\    /    |  | |  |\   | |  |\   |  /  _____  \  |  .  \  |  |____ |  |\  \----.
    \__/  \__/     |__| |__| \__| |__| \__| /__/     \__\ |__|\__\ |_______|| _| `._____|

2017-06-18 12:45:13,812 [INFO]  Winnaker Version: 0.5.0
2017-06-18 12:45:13,812 [INFO]  Current Config: Namespace(app='edwintestapp', forcebake=False, headless=False, nolastbuild=True, nologin=False, pipeline='test', start=True, verbose=False)
2017-06-18 12:45:26,338 [INFO]  - Logged in to the spinnaker
2017-06-18 12:45:29,772 [INFO]  - Searched for application: edwintestapp
2017-06-18 12:45:34,888 [INFO]  - Selected pipeline: test successfully
2017-06-18 12:45:40,422 [INFO]  - Starting Manual Execution
2017-06-18 12:45:50,423 [INFO]  	 Running ... (will wait up to 100 minutes
  0%|                                                                      | 0/600 [00:00<?, ?it/s]2017-06-18 12:45:50,539 [INFO]  Username: Edwin.Avalos@target.com
2017-06-18 12:45:51,936 [ERROR]  Pipeline stopped with terminal state. screenshot generated.
2017-06-18 12:45:51,936 [ERROR]
    !!!!!!!!!!!!!!!!!!
        FAILED
    !!!!!!!!!!!!!!!!!!
```

I also fixed up some values in config.sh that had extra ]s that I got in somehow...
