### PR TITLE
Default variables if they are not set to None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os.path import join, dirname
 setup(name='winnaker',
       description='An audit tool that tests the whole system functionality of Spinnaker',
       author='Target Corporation',
-      version='1.0.0',
+      version='1.0.1',
       license='MIT',
       packages=find_packages(),
       install_requires=[

--- a/winnaker/main.py
+++ b/winnaker/main.py
@@ -90,7 +90,7 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
     if not os.path.exists(cfg_output_files_path):
         os.makedirs(cfg_output_files_path)
 
-    if (cfg_email_smtp != "") and (cfg_email_to != ""):
+    if cfg_email_smtp and cfg_email_to and cfg_email_from:
         atexit.register(send_mail, cfg_email_from, cfg_email_to, "Winnaker Screenshots " +
                         str(datetime.utcnow()), "Here are the screenshots of the spinnaker's last run at " +
                         str(datetime.utcnow()) +

--- a/winnaker/models.py
+++ b/winnaker/models.py
@@ -54,7 +54,7 @@ class Spinnaker():
         e.send_keys(cfg_spinnaker_password)
         e = wait_for_xpath_presence(self.driver, cfg_signin_button_xpath)
         e.click()
-        logging.info("- Logged in to the spinnaker")
+        logging.info("- Logged in to the spinnaker instance at {}".format(cfg_spinnaker_url))
         self.driver.save_screenshot(join(cfg_output_files_path, "login2.png"))
         time.sleep(3)
 

--- a/winnaker/settings.py
+++ b/winnaker/settings.py
@@ -2,17 +2,16 @@ import os
 from dotenv import load_dotenv
 from os.path import join, dirname
 from dotenv import load_dotenv
-import logging
 
 
 def get_env(env_key, default):
     value = os.getenv(env_key)
     if value is None or len(value) == 0:
-        logging.debug(
-            "{} not set in environment, defaulting to {}".format(
+        print(
+            "INFO: {} not set in environment, defaulting to {}".format(
                 env_key, default))
         return default
-    logging.debug("{} set from environment".format(env_key))
+    print("INFO: {} set from environment".format(env_key))
     return value
 
 
@@ -26,14 +25,14 @@ cfg_output_files_path = os.environ["WINNAKER_OUTPUTPATH"]
 cfg_spinnaker_url = os.environ["WINNAKER_SPINNAKER_URL"]
 cfg_spinnaker_username = os.environ["WINNAKER_USERNAME"]
 cfg_spinnaker_password = os.environ['WINNAKER_PASSWORD']
-cfg_max_wait_for_pipeline_run_mins = int(
-    os.environ["WINNAKER_MAX_WAIT_PIPELINE"]) * 60.00
+cfg_max_wait_for_pipeline_run_mins = int(int(
+    get_env("WINNAKER_MAX_WAIT_PIPELINE", 100)) * 60.00)
 
 # Notification Settings
-cfg_email_smtp = os.environ["WINNAKER_EMAIL_SMTP"]
-cfg_email_from = os.environ["WINNAKER_EMAIL_FROM"]
-cfg_email_to = os.environ["WINNAKER_EMAIL_TO"]
-cfg_hipchat_posturl = os.environ['WINNAKER_HIPCHAT_POSTURL']
+cfg_email_smtp = get_env("WINNAKER_EMAIL_SMTP", None)
+cfg_email_from = get_env("WINNAKER_EMAIL_FROM", None)
+cfg_email_to = get_env("WINNAKER_EMAIL_TO", None)
+cfg_hipchat_posturl = get_env('WINNAKER_HIPCHAT_POSTURL', None)
 
 # ---------------------------------------------
 # Internal Configs


### PR DESCRIPTION
Max wait I defaulted to 100, it seems silly to set that to None

Changed some settings checking code appropriate based on None

Removed logging from settings.py. It was causing a new unconfigured logger to be added, and it duplicates all log messages. I reworked it to just print INFO messages about how settings were set.

Currently those info messages at the beginning are NOT sent to the log file.

Recommendations for another PR:

Move the logging setup and argparse into the settings.py (Or look at the config setup again, it still seems a bit weird)