### PR TITLE
Fix typo, consistent naming

### DIFF
--- a/winnaker/models.py
+++ b/winnaker/models.py
@@ -112,7 +112,7 @@ class Spinnaker():
         time.sleep(2)
         if force_bake:
             e = wait_for_xpath_presence(
-                self.driver, cfg_force_bake_xpath, be_clickable=True)
+                self.driver, cfg_force_rebake_xpath, be_clickable=True)
             move_to_element(self.driver, e, click=True)
             time.sleep(2)
             if not e.get_attribute('checked'):

--- a/winnaker/settings.py
+++ b/winnaker/settings.py
@@ -66,9 +66,6 @@ cfg_searchbox_xpath = get_env(
 cfg_start_manual_execution_xpath = get_env(
     "WINNAKER_XPATH_START_MANUAL_EXECUTION",
     "//div[contains(@class, 'execution-group-actions')]/h4[2]/a/span")
-cfg_froce_rebake_xpath = get_env(
-    "WINNAKER_XPATH_FORCE_REBAKE",
-    "//input[@type='checkbox' and @ng-model='vm.command.trigger.rebake']")
-cfg_force_rebake_check_xpath = get_env(
+cfg_force_rebake_xpath = get_env(
     "WINNAKER_XPATH_FORCE_REBAKE",
     "//input[@type='checkbox' and @ng-model='vm.command.trigger.rebake']")


### PR DESCRIPTION
cfg_force_bake_xpath is undefined due to a typo in settings.py.

It also appears that cfg_force_rebake_xpath is the same as cfg_force_rebake_check_xpath.

