### PR TITLE
wait for authorize screen and click if it appears

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Auditing tool for Spinnaker. Real Testing in real browser !
 
 
 	```
-	cp .env-sample .env
+	cp winnaker/.env-sample .env
 
 	```
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os.path import join, dirname
 setup(name='winnaker',
       description='An audit tool that tests the whole system functionality of Spinnaker',
       author='Target Corporation',
-      version='1.0.3',
+      version='1.1.0',
       license='MIT',
       packages=find_packages(),
       install_requires=[

--- a/winnaker/main.py
+++ b/winnaker/main.py
@@ -45,8 +45,16 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
         type=str,
         help="the name of pipline to test",
         default=os.environ["WINNAKER_PIPELINE_NAME"])
-    parser.add_argument("-nl", "--nologin",
-                        help="will not attempt to login", action="store_true")
+    parser.add_argument(
+        "-nl", "--nologin",
+        help="will not attempt to login",
+        action="store_true")
+    parser.add_argument(
+        "-oa", "--authorize",
+        help="authorize the oauth application with the logged in user if required. " +
+            "This argument and '--nologin' are mutually exclusive",
+        action="store_true"
+    )
     parser.add_argument(
         "-nlb",
         "--nolastbuild",
@@ -107,6 +115,8 @@ ____    __    ____  __  .__   __. .__   __.      ___       __  ___  _______ .___
     if not args.nologin:
         logging.debug("Starting login")
         s.login()
+        if args.authorize: s.authorize()
+
     s.get_pipeline(args.app, args.pipeline)
     if not args.nolastbuild:
         logging.info(

--- a/winnaker/models.py
+++ b/winnaker/models.py
@@ -41,6 +41,17 @@ class Spinnaker():
         if not os.path.exists(cfg_output_files_path):
             os.makedirs(cfg_output_files_path)
 
+    def authorize(self):
+        logging.debug("Authorizing OAuth Request")
+        try:
+            e = wait_for_xpath_presence(self.driver, cfg_oauth_authorize_xpath, stop_max_attempt=2)
+            self.driver.save_screenshot(join(
+                cfg_output_files_path, "authorize.png"))
+            e.click()
+        except:
+            logging.debug("couldn't find authorize xpath. This is OK if the user has already been authorized, looked for: %s"
+                % cfg_oauth_authorize_xpath)
+
     def login(self):
         self.check_page_contains_error()
         e = wait_for_xpath_presence(self.driver, cfg_usernamebox_xpath)

--- a/winnaker/settings.py
+++ b/winnaker/settings.py
@@ -34,6 +34,17 @@ cfg_email_from = get_env("WINNAKER_EMAIL_FROM", None)
 cfg_email_to = get_env("WINNAKER_EMAIL_TO", None)
 cfg_hipchat_posturl = get_env('WINNAKER_HIPCHAT_POSTURL', None)
 
+# Retry settings
+cfg_wait_exponential_multiplier = get_env(
+    "WINNAKER_WAIT_EXPONENTIAL_MULTIPLIER",
+    10)
+cfg_wait_exponential_max= get_env(
+    "WINNAKER_WAIT_EXPONENTIAL_MAX",
+    5000)
+cfg_retry_stop_max_attempt = get_env(
+    "WINNAKER_RETRY_STOP_MAX_ATTEMPT",
+    10)
+
 # ---------------------------------------------
 # Internal Configs
 #
@@ -69,3 +80,7 @@ cfg_start_manual_execution_xpath = get_env(
 cfg_force_rebake_xpath = get_env(
     "WINNAKER_XPATH_FORCE_REBAKE",
     "//input[@type='checkbox' and @ng-model='vm.command.trigger.rebake']")
+
+cfg_oauth_authorize_xpath= get_env(
+    "WINNAKER_XPATH_OAUTH_AUTHORIZE",
+    "//*[@id='js-oauth-authorize-btn']")


### PR DESCRIPTION
This PR adds additional logic for winnaker to authorize a login if the login is oauth.  If configured, after login, Winnaker will check to see if there is an authorization screen.  This is conditional because in some cases you might only authorize the login once and it won't appear again.

This was tested against Github's OAuth flow.  Additionally, github tends to show the authorize screen multiple times unexpectedly so this PR handles that use-case.

![authorize](https://cl.ly/140h2Q2v2x1U/Image%202017-08-11%20at%202.42.59%20PM.png)

other changes:
* adds configurable retry logic
* add missing .env.sample file that was referenced by the README